### PR TITLE
feat: add support for useSafeArea and for embedding outside of a dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # EasyImageViewer Changelog
 
-## 1.0.0
+## 1.0.3
 
-- Initial version.
-
-## 1.0.1
-
-- Update demo image path in README.
+- Add `useSafeArea` argument that defaults to `false` and pass it through to `showDialog` to let a zoomed-in image fill the entire screen.
+- Use `SizedBox.expand` to make `EasyImageView` fill its parent instead of hard-coding its size to the full screen.
+- Add example of how to use `EasyImageViewPager` without a dialog, embedding it in a widget and using buttons to go forward and backward.
 
 ## 1.0.2
 
 - Provide more comprehensive example.
 - Structure lib directory using a src folder.
+
+## 1.0.1
+
+- Update demo image path in README.
+
+## 1.0.0
+
+- Initial version.

--- a/example/lib/embedded.dart
+++ b/example/lib/embedded.dart
@@ -1,0 +1,91 @@
+import 'package:easy_image_viewer/easy_image_viewer.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EasyImageViewer Demo',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'EasyImageViewer Demo'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  final String title;
+
+  const MyHomePage({
+    Key? key,
+    required this.title,
+  }) : super(key: key);
+
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  final _pageController = PageController();
+  static const _kDuration = Duration(milliseconds: 300);
+  static const _kCurve = Curves.ease;
+
+  final _easyImageProvider = MultiImageProvider([
+    Image.network("https://picsum.photos/id/1001/5616/3744").image,
+    Image.network("https://picsum.photos/id/1003/1181/1772").image,
+    Image.network("https://picsum.photos/id/1004/5616/3744").image,
+    Image.network("https://picsum.photos/id/1005/5760/3840").image
+  ]);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+          child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: MediaQuery.of(context).size.width,
+            height: MediaQuery.of(context).size.height / 2.0,
+            child: EasyImageViewPager(
+                easyImageProvider: _easyImageProvider,
+                pageController: _pageController),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              ElevatedButton(
+                  child: const Text("<< Prev"),
+                  onPressed: () {
+                    final currentPage = _pageController.page?.toInt() ?? 0;
+                    _pageController.animateToPage(
+                        currentPage > 0 ? currentPage - 1 : 0,
+                        duration: _kDuration,
+                        curve: _kCurve);
+                  }),
+              ElevatedButton(
+                  child: const Text("Next >>"),
+                  onPressed: () {
+                    final currentPage = _pageController.page?.toInt() ?? 0;
+                    final lastPage = _easyImageProvider.imageCount - 1;
+                    _pageController.animateToPage(
+                        currentPage < lastPage ? currentPage + 1 : lastPage,
+                        duration: _kDuration,
+                        curve: _kCurve);
+                  }),
+            ],
+          )
+        ],
+      )),
+    );
+  }
+}

--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -19,13 +19,17 @@ export 'src/easy_image_view_pager.dart' show EasyImageViewPager;
 /// Shows the given [imageProvider] in a full-screen [Dialog].
 /// Setting [immersive] to false will prevent the top and bottom bars from being hidden.
 /// The optional [onViewerDismissed] callback function is called when the dialog is closed.
+/// The optional [useSafeArea] boolean defaults to false and is passed to [showDialog].
 Future<Dialog?> showImageViewer(
     BuildContext context, ImageProvider imageProvider,
-    {bool immersive = true, void Function()? onViewerDismissed}) {
+    {bool immersive = true,
+    void Function()? onViewerDismissed,
+    bool useSafeArea = false}) {
   return showImageViewerPager(context, SingleImageProvider(imageProvider),
       immersive: immersive,
       onViewerDismissed:
-          onViewerDismissed != null ? (_) => onViewerDismissed() : null);
+          onViewerDismissed != null ? (_) => onViewerDismissed() : null,
+      useSafeArea: useSafeArea);
 }
 
 /// Shows the images provided by the [imageProvider] in a full-screen PageView [Dialog].
@@ -34,6 +38,7 @@ Future<Dialog?> showImageViewer(
 /// the image when the user has swiped to another image.
 /// The optional [onViewerDismissed] callback function is called with the index of
 /// the image that is displayed when the dialog is closed.
+/// The optional [useSafeArea] boolean defaults to false and is passed to [showDialog].
 /// The [closeButtonTooltip] text is displayed when the user long-presses on the
 /// close button and is used for accessibility.
 Future<Dialog?> showImageViewerPager(
@@ -41,6 +46,7 @@ Future<Dialog?> showImageViewerPager(
     {bool immersive = true,
     void Function(int)? onPageChanged,
     void Function(int)? onViewerDismissed,
+    bool useSafeArea = false,
     String closeButtonTooltip = 'Close'}) {
   if (immersive) {
     // Hide top and bottom bars
@@ -60,6 +66,7 @@ Future<Dialog?> showImageViewerPager(
 
   return showDialog<Dialog>(
       context: context,
+      useSafeArea: useSafeArea,
       builder: (context) {
         return Dialog(
             backgroundColor: Colors.black,

--- a/lib/src/easy_image_view.dart
+++ b/lib/src/easy_image_view.dart
@@ -34,10 +34,8 @@ class _EasyImageViewState extends State<EasyImageView> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
+    return SizedBox.expand(
         key: const Key('easy_image_sized_box'),
-        width: MediaQuery.of(context).size.width,
-        height: MediaQuery.of(context).size.height,
         child: InteractiveViewer(
           key: const Key('easy_image_interactive_viewer'),
           transformationController: _transformationController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_image_viewer
 description: An easy image viewer with pinch & zoom, multi image, and built-in full-screen dialog support.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:

--- a/test/easy_image_view_test.dart
+++ b/test/easy_image_view_test.dart
@@ -35,8 +35,8 @@ void main() {
 
       // Check properties
       SizedBox sizedBox = tester.firstWidget(sizedBoxFinder);
-      expect(sizedBox.width, 600);
-      expect(sizedBox.height, 800);
+      expect(sizedBox.width, double.infinity);
+      expect(sizedBox.height, double.infinity);
       InteractiveViewer interactiveViewer =
           tester.firstWidget(interactiveViewFinder);
       expect(interactiveViewer.minScale, 0.5);


### PR DESCRIPTION
## Description

In order to fill the whole screen with an image, the `useSafeArea` option
of the `showDialog` call can now be passed through, and it defaults to false.

Also, the size of `EasyImageView` is now not hard-coded to the size of the screen,
but instead uses `SizedBox.expand` to fill its parent. This enables embedding
of `EasyImageView` and `EasyImageViewPager` inside of another widget, without
using a `Dialog`.

Also adds an example of how to do that.



<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->

Todo

## Checklist

Please ensure your pull request fulfills the following requirements:

- [x] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Tests for any changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[x] Bug fix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[x] No
```
