### PR TITLE
Enable dragging the PageView with a mouse (GH-11)

### DIFF
--- a/lib/src/easy_image_view_pager.dart
+++ b/lib/src/easy_image_view_pager.dart
@@ -1,7 +1,16 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'easy_image_provider.dart';
 import 'easy_image_view.dart';
+
+/// Custom ScrollBehavior that allows dragging with all pointers
+/// including the normally excluded mouse
+class MouseEnabledScrollBehavior extends MaterialScrollBehavior {
+  // Override behavior methods and getters like dragDevices
+  @override
+  Set<PointerDeviceKind> get dragDevices => PointerDeviceKind.values.toSet();
+}
 
 /// PageView for swiping through a list of images
 class EasyImageViewPager extends StatefulWidget {
@@ -35,6 +44,7 @@ class _EasyImageViewPagerState extends State<EasyImageViewPager> {
       key: const Key('easy_image_view_page_view'),
       itemCount: widget.easyImageProvider.imageCount,
       controller: pageController,
+      scrollBehavior: MouseEnabledScrollBehavior(),
       itemBuilder: (context, index) {
         final image = widget.easyImageProvider.imageBuilder(context, index);
         return EasyImageView(


### PR DESCRIPTION
## Description

By default page views (and scroll views in general) can only be
dragged with touch devices, not mice.
That means it was impossible to advance to the next image on desktop
(Windows).
This commit enables dragging with a mouse. Since the images are
displayed full-screen, it shouldn't interfere with anything else.

For more references, see:
https://stackoverflow.com/questions/69424933/flutter-pageview-not-swipeable-on-web-desktop-mode
https://docs.flutter.dev/release/breaking-changes/default-scroll-behavior-drag
https://www.reddit.com/r/flutterhelp/comments/thyl47/how_to_use_arrow_keys_or_mouse_swipe_for_pageview/


## Checklist

Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [X] Tests for any changes have been added (not necessary)

## Type

What kind of change does this pull request introduce?

[X] Bug fix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)

## Breaking Changes

Does this pull request introduce any breaking changes?

[ ] Yes
[X] No
