### PR TITLE
fix: used confirmDismiss instead of changing direction

### DIFF
--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -175,11 +175,7 @@ class _EasyImageViewerDismissableDialogState extends State<EasyImageViewerDismis
                 direction: _dismissDirection,
                 resizeDuration: null,
                 confirmDismiss: (_) async {
-                  if (_canDismiss) {
-                    return true;
-                  } else {
-                    return false;
-                  }
+                  return _canDismiss;
                 },
                 onDismissed: (_) {
                   Navigator.of(context).pop();

--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -120,6 +120,7 @@ class EasyImageViewerDismissableDialog extends StatefulWidget {
 class _EasyImageViewerDismissableDialogState extends State<EasyImageViewerDismissableDialog> with AutomaticKeepAliveClientMixin {
   
   DismissDirection _dismissDirection = DismissDirection.down;
+  bool _canDismiss = true;
   final PageController _pageController = PageController();
 
   _EasyImageViewerDismissableDialogState() : super() {
@@ -140,7 +141,7 @@ class _EasyImageViewerDismissableDialogState extends State<EasyImageViewerDismis
                 EasyImageViewPager(easyImageProvider: widget.imageProvider, pageController: _pageController, onScaleChanged: (scale) {
                   setState(() {
                     print("setState. old $_dismissDirection");
-                    _dismissDirection = scale <= 1.0 ? DismissDirection.down : DismissDirection.none;
+                    _canDismiss = scale <= 1.0;
                     print("setState. new $_dismissDirection ${_pageController.page}");
                   });
                 }),
@@ -173,6 +174,13 @@ class _EasyImageViewerDismissableDialogState extends State<EasyImageViewerDismis
             return Dismissible(
                 direction: _dismissDirection,
                 resizeDuration: null,
+                confirmDismiss: (_) async {
+                  if (_canDismiss) {
+                    return true;
+                  } else {
+                    return false;
+                  }
+                },
                 onDismissed: (_) {
                   Navigator.of(context).pop();
                 },


### PR DESCRIPTION
## Description

<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->
Instead of changing direction to not allow the user to dismiss the viewer, the confirmDismiss property can be used to veto the dismissing functionality.

## Checklist

Please ensure your pull request fulfills the following requirements:

- [x] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Tests for any changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[x] Bug fix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[x] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

n/a
