### PR TITLE
fix: correctly clean up when using the Android back button to dismiss

### DIFF
--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -83,11 +83,36 @@ Future<Dialog?> showImageViewerPager(
     pageController.addListener(internalPageChangeListener);
   }
 
+  // internal function to be called whenever the dialog
+  // is dismissed, whether through the Android back button,
+  // or through the "x" close button.
+  handleDismissal() {
+    if (onViewerDismissed != null) {
+      onViewerDismissed(
+          pageController.page?.round() ?? 0);
+    }
+
+    if (immersive) {
+      SystemChrome.setEnabledSystemUIMode(
+          SystemUiMode.edgeToEdge);
+    }
+    if (internalPageChangeListener != null) {
+      pageController
+          .removeListener(internalPageChangeListener);
+    }
+    pageController.dispose();
+  }
+
   return showDialog<Dialog>(
       context: context,
       useSafeArea: useSafeArea,
       builder: (context) {
-        return Dialog(
+        return WillPopScope(
+          onWillPop: () async {
+            handleDismissal();
+            return true;
+          },
+          child: Dialog(
             backgroundColor: backgroundColor,
             insetPadding: const EdgeInsets.all(0),
             child: Stack(
@@ -107,22 +132,10 @@ Future<Dialog?> showImageViewerPager(
                         onPressed: () {
                           Navigator.of(context).pop();
 
-                          if (onViewerDismissed != null) {
-                            onViewerDismissed(
-                                pageController.page?.round() ?? 0);
-                          }
-
-                          if (immersive) {
-                            SystemChrome.setEnabledSystemUIMode(
-                                SystemUiMode.edgeToEdge);
-                          }
-                          if (internalPageChangeListener != null) {
-                            pageController
-                                .removeListener(internalPageChangeListener);
-                          }
-                          pageController.dispose();
+                          handleDismissal();
                         },
                       ))
-                ]));
+                ]))
+        );
       });
 }


### PR DESCRIPTION
## Description

When using the Android back button to dismiss the dialog, we were not
running the same cleanup code that we run when pressing the X close button.

This is now changed and it caused the Android status bar to re-appear
when using the back button.

Closes #15

## Type

```
[X] Bug fix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[X] No
```


