### PR TITLE
fix: Don't use rounded corners on the full-screen dialog

### DIFF
--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -90,6 +90,9 @@ Future<Dialog?> showImageViewerPager(
         return Dialog(
             backgroundColor: backgroundColor,
             insetPadding: const EdgeInsets.all(0),
+            // We set the shape here to ensure no rounded corners allow any of the 
+            // underlying view to show. We want the whole background to be covered.
+            shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero),
             child: Stack(
                 clipBehavior: Clip.none,
                 alignment: Alignment.center,


### PR DESCRIPTION
## Description

When setting `useMaterial3` to `true` on the ThemeData, we got rounded
corners on the dialog that let some of the underlying view show.
We want the dialog to completely cover the underlying view, so we
simple set the corner radius to zero.

Fixes #16

<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->

## Checklist

Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [ ] Tests for any changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[X] Bug fix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[X] No
```

