### PR TITLE
Update to Dart >=2.12.0 <4.0.0, add topics to pubspec

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'master'
+          channel: 'stable'
       - name: Install dependencies
         run: flutter pub get
       - name: Analyze project source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EasyImageViewer Changelog
 
+## 1.2.1
+
+- Update Dart to `>=2.12.0 <4.0.0`.
+
 ## 1.2.0
 
 - Add option to "double tap to zoom" by setting `doubleTapZoomable` to `true` [GH-24](https://github.com/thesmythgroup/easy_image_viewer/issues/24). Thank you to [Tony](https://github.com/nne998) of [lookingpet](https://github.com/lookingpet/easy_image_viewer) for the initial implementation.

--- a/lib/src/easy_image_view.dart
+++ b/lib/src/easy_image_view.dart
@@ -30,7 +30,7 @@ class EasyImageView extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _EasyImageViewState createState() => _EasyImageViewState();
+  State<EasyImageView> createState() => _EasyImageViewState();
 }
 
 class _EasyImageViewState extends State<EasyImageView>

--- a/lib/src/easy_image_view_pager.dart
+++ b/lib/src/easy_image_view_pager.dart
@@ -34,7 +34,7 @@ class EasyImageViewPager extends StatefulWidget {
       : super(key: key);
 
   @override
-  _EasyImageViewPagerState createState() => _EasyImageViewPagerState();
+  State<EasyImageViewPager> createState() => _EasyImageViewPagerState();
 }
 
 class _EasyImageViewPagerState extends State<EasyImageViewPager> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,18 @@
 name: easy_image_viewer
 description: An easy image viewer with pinch & zoom, multi image, and built-in full-screen dialog support.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
   flutter: ">=1.17.0"
+
+topics:
+  - image
+  - photo
+  - slideshow
+  - pager
+  - zoom
 
 dependencies:
   flutter:
@@ -14,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1


### PR DESCRIPTION
## Description

Since Dart 3 was released, update the pub spec to reflect that we are compatible with Dart 3.

