### PR TITLE
GH #34: Initial work to add loading indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # EasyImageViewer Changelog
 
+## 1.3.0
+
+- Update Flutter to `3.16.3`
+- Add loading progress indicator out of the box with options to fully customize both the widget used to display progress as well as the widget used to display an image (Flutter's `Image` by default).
+
 ## 1.2.1
 
 - Update Dart to `>=2.12.0 <4.0.0`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An easy way to display images in a full-screen dialog, including pinch & zoom.
 * Optionally allow "swipe down to dismiss" by passing in `swipeDismissible: true`
 * No dependencies besides Flutter
 * Callbacks for `onPageChanged` and `onViewerDismissed`
+* Fully customizable loading/progress indicator
 
 ## Usage
 
@@ -87,6 +88,60 @@ showImageViewerPager(context, productsImageProvider, onPageChanged: (page) {
   print("dismissed while on page $page");
 });
 ```
+
+## Customizing Progress Indicator and Image Widget
+
+You can subclass `EasyImageProvider` and override `progressIndicatorWidgetBuilder`. That way you can
+provide your own progress indicator when an image is loading. Here's an example for using a
+linear progress indicator with a label:
+
+```dart
+class CustomImageWidgetProvider extends EasyImageProvider {
+  @override
+  final int initialIndex;
+  final List<String> imageUrls;
+
+  CustomImageWidgetProvider({required this.imageUrls, this.initialIndex = 0})
+      : super();
+
+  @override
+  ImageProvider<Object> imageBuilder(BuildContext context, int index) {
+    return NetworkImage(imageUrls[index]);
+  }
+
+  @override
+  Widget progressIndicatorWidgetBuilder(BuildContext context, int index, {double? value}) {
+    // Create a custom linear progress indicator
+    // with a label showing the progress value
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        LinearProgressIndicator(
+          value: value,
+        ),
+        Text(
+          "${(value ?? 0) * 100}%",
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 20,
+          ),
+        )
+      ],
+    );
+  }
+
+  @override
+  int get imageCount => imageUrls.length;
+}
+```
+
+You can also adjust `animationDuration` and `animationCurve` for the transition that is used
+to fade in the loaded image.
+
+Finally, you can even override the `imageWidgetBuilder` method and completely customize the
+appearance of each individual image. Keep in mind that it should be an "image-like" widget 
+since it will be treated as such: the user can pinch&zoom the returned widget etc.
 
 ## How to release a new version on pub.dev
 1. Update the version number in `pubspec.yaml`.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Show a bunch of images:
 
 ```dart
 MultiImageProvider multiImageProvider = MultiImageProvider([
-  Image.network("https://picsum.photos/id/1001/5616/3744").image,
-  Image.network("https://picsum.photos/id/1003/1181/1772").image,
-  Image.network("https://picsum.photos/id/1004/5616/3744").image,
-  Image.network("https://picsum.photos/id/1005/5760/3840").image
+  const NetworkImage("https://picsum.photos/id/1001/4912/3264"),
+  const NetworkImage("https://picsum.photos/id/1003/1181/1772"),
+  const NetworkImage("https://picsum.photos/id/1004/4912/3264"),
+  const NetworkImage("https://picsum.photos/id/1005/4912/3264")
 ]);
 
 showImageViewerPager(context, multiImageProvider, onPageChanged: (page) {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,10 +38,10 @@ class _MyHomePageState extends State<MyHomePage> {
   static const _kCurve = Curves.ease;
 
   final List<ImageProvider> _imageProviders = [
-    Image.network("https://picsum.photos/id/1001/4912/3264").image,
-    Image.network("https://picsum.photos/id/1003/1181/1772").image,
-    Image.network("https://picsum.photos/id/1004/4912/3264").image,
-    Image.network("https://picsum.photos/id/1005/4912/3264").image
+    const NetworkImage("https://picsum.photos/id/1001/4912/3264"),
+    const NetworkImage("https://picsum.photos/id/1003/1181/1772"),
+    const NetworkImage("https://picsum.photos/id/1004/4912/3264"),
+    const NetworkImage("https://picsum.photos/id/1005/4912/3264")
   ];
 
   late final _easyEmbeddedImageProvider = MultiImageProvider(_imageProviders);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,6 +13,7 @@ class MyApp extends StatelessWidget {
       title: 'EasyImageViewer Demo',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
+        progressIndicatorTheme: const ProgressIndicatorThemeData(color: Colors.green),
         primarySwatch: Colors.blue,
       ),
       home: const MyHomePage(title: 'EasyImageViewer Demo'),
@@ -100,6 +101,19 @@ class _MyHomePageState extends State<MyHomePage> {
                   MaterialPageRoute(builder: (context) => const AsyncDemoPage()),
                 );
               }),
+          ElevatedButton(
+              child: const Text("Custom Progress Indicator"),
+              onPressed: () {
+                CustomImageWidgetProvider customImageProvider = CustomImageWidgetProvider(
+                    imageUrls: [
+                      "https://picsum.photos/id/1001/4912/3264",
+                      "https://picsum.photos/id/1003/1181/1772",
+                      "https://picsum.photos/id/1004/4912/3264",
+                      "https://picsum.photos/id/1005/4912/3264"
+                    ].toList(),
+                );
+                showImageViewerPager(context, customImageProvider);
+              }),
           SizedBox(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height / 2.0,
@@ -148,6 +162,45 @@ class CustomImageProvider extends EasyImageProvider {
   @override
   ImageProvider<Object> imageBuilder(BuildContext context, int index) {
     return NetworkImage(imageUrls[index]);
+  }
+
+  @override
+  int get imageCount => imageUrls.length;
+}
+
+class CustomImageWidgetProvider extends EasyImageProvider {
+  @override
+  final int initialIndex;
+  final List<String> imageUrls;
+
+  CustomImageWidgetProvider({required this.imageUrls, this.initialIndex = 0})
+      : super();
+
+  @override
+  ImageProvider<Object> imageBuilder(BuildContext context, int index) {
+    return NetworkImage(imageUrls[index]);
+  }
+
+  @override
+  Widget progressIndicatorWidgetBuilder(BuildContext context, int index, {double? value}) {
+    // Create a custom linear progress indicator
+    // with a label showing the progress value
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        LinearProgressIndicator(
+          value: value,
+        ),
+        Text(
+          "${(value ?? 0) * 100}%",
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 20,
+          ),
+        )
+      ],
+    );
   }
 
   @override

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -182,7 +182,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -235,6 +235,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -344,7 +345,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -423,7 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -470,7 +471,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/src/easy_image_provider.dart
+++ b/lib/src/easy_image_provider.dart
@@ -21,18 +21,20 @@ abstract class EasyImageProvider {
   Widget imageWidgetBuilder(BuildContext context, int index) {
     return Image(
       image: imageBuilder(context, index),
-      frameBuilder: (BuildContext context, Widget child, int? frame, bool wasSynchronouslyLoaded) {
+      frameBuilder: (BuildContext context, Widget child, int? frame,
+          bool wasSynchronouslyLoaded) {
         if (wasSynchronouslyLoaded) {
           return child;
         }
         return AnimatedOpacity(
           opacity: frame == null ? 0 : 1,
-          duration: animationDuration,  
+          duration: animationDuration,
           curve: animationCurve,
           child: child,
         );
       },
-      loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent? loadingProgress) {
+      loadingBuilder: (BuildContext context, Widget child,
+          ImageChunkEvent? loadingProgress) {
         bool shouldShowLoading = loadingProgress != null;
         return IndexedStack(
           index: shouldShowLoading ? 1 : 0,
@@ -43,8 +45,11 @@ abstract class EasyImageProvider {
               context,
               index,
               value: loadingProgress?.expectedTotalBytes != null
-                  ? loadingProgress!.cumulativeBytesLoaded / loadingProgress.expectedTotalBytes!
-                  : shouldShowLoading ? null : 0.0,
+                  ? loadingProgress!.cumulativeBytesLoaded /
+                      loadingProgress.expectedTotalBytes!
+                  : shouldShowLoading
+                      ? null
+                      : 0.0,
             ),
           ],
         );
@@ -59,7 +64,8 @@ abstract class EasyImageProvider {
   /// If [value] is null, the progress indicator is in indeterminate mode.
   /// The [index] parameter is the index of the image being loaded.
   /// The [context] parameter is the build context.
-  Widget progressIndicatorWidgetBuilder(BuildContext context, int index, {double? value}) {
+  Widget progressIndicatorWidgetBuilder(BuildContext context, int index,
+      {double? value}) {
     return CircularProgressIndicator(
       value: value,
     );

--- a/lib/src/easy_image_provider.dart
+++ b/lib/src/easy_image_provider.dart
@@ -10,4 +10,36 @@ abstract class EasyImageProvider {
 
   /// Returns the image for the given [index].
   ImageProvider imageBuilder(BuildContext context, int index);
+
+  /// Returns the image widget for the given [index].
+  Widget imageWidgetBuilder(BuildContext context, int index) {
+    return Image(
+      image: imageBuilder(context, index),
+      frameBuilder: (BuildContext context, Widget child, int? frame, bool wasSynchronouslyLoaded) {
+        if (wasSynchronouslyLoaded) {
+          return child;
+        }
+        return AnimatedOpacity(
+          opacity: frame == null ? 0 : 1,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+          child: child,
+        );
+      },
+      loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent? loadingProgress) {
+        return IndexedStack(
+          index: loadingProgress == null ? 0 : 1,
+          alignment: Alignment.center,
+          children: <Widget>[
+            child,
+            CircularProgressIndicator(
+              value: loadingProgress?.expectedTotalBytes != null
+                  ? loadingProgress!.cumulativeBytesLoaded / loadingProgress.expectedTotalBytes!
+                  : null,
+            ),
+          ],
+        );
+      },
+    );
+  }
 }

--- a/lib/src/easy_image_provider.dart
+++ b/lib/src/easy_image_provider.dart
@@ -8,6 +8,12 @@ abstract class EasyImageProvider {
   /// Total count of images
   int get imageCount;
 
+  /// Animation duration for the image transition (fade in after loading)
+  Duration animationDuration = const Duration(milliseconds: 300);
+
+  /// Animation curve for the image transition (fade in after loading)
+  Curve animationCurve = Curves.easeOut;
+
   /// Returns the image for the given [index].
   ImageProvider imageBuilder(BuildContext context, int index);
 
@@ -21,25 +27,41 @@ abstract class EasyImageProvider {
         }
         return AnimatedOpacity(
           opacity: frame == null ? 0 : 1,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeOut,
+          duration: animationDuration,  
+          curve: animationCurve,
           child: child,
         );
       },
       loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent? loadingProgress) {
+        bool shouldShowLoading = loadingProgress != null;
         return IndexedStack(
-          index: loadingProgress == null ? 0 : 1,
+          index: shouldShowLoading ? 1 : 0,
           alignment: Alignment.center,
           children: <Widget>[
             child,
-            CircularProgressIndicator(
+            progressIndicatorWidgetBuilder(
+              context,
+              index,
               value: loadingProgress?.expectedTotalBytes != null
                   ? loadingProgress!.cumulativeBytesLoaded / loadingProgress.expectedTotalBytes!
-                  : null,
+                  : shouldShowLoading ? null : 0.0,
             ),
           ],
         );
       },
+    );
+  }
+
+  /// Returns the progress indicator widget for the given [index].
+  /// The default implementation returns a [CircularProgressIndicator].
+  /// Override this method to customize the progress indicator.
+  /// The [value] parameter is the progress value between 0.0 and 1.0.
+  /// If [value] is null, the progress indicator is in indeterminate mode.
+  /// The [index] parameter is the index of the image being loaded.
+  /// The [context] parameter is the build context.
+  Widget progressIndicatorWidgetBuilder(BuildContext context, int index, {double? value}) {
+    return CircularProgressIndicator(
+      value: value,
     );
   }
 }

--- a/lib/src/easy_image_view.dart
+++ b/lib/src/easy_image_view.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 /// A full-sized view that displays the given image, supporting pinch & zoom
 class EasyImageView extends StatefulWidget {
-  /// The image to display
-  final ImageProvider imageProvider;
+  /// The image widget to display
+  final Widget imageWidget;
 
   /// Minimum scale factor
   final double minScale;
@@ -18,11 +18,27 @@ class EasyImageView extends StatefulWidget {
   /// an interaction.
   final void Function(double)? onScaleChanged;
 
+  /// Create a new instance that accepts an [ImageProvider]
+  EasyImageView.provider(ImageProvider imageProvider,
+      {Key? key,
+      double minScale = 1.0,
+      double maxScale = 5.0,
+      bool doubleTapZoomable = false,
+      void Function(double)? onScaleChanged})
+      : this(
+          key: key,
+          imageWidget: Image(image: imageProvider),
+          minScale: minScale,
+          maxScale: maxScale,
+          doubleTapZoomable: doubleTapZoomable,
+          onScaleChanged: onScaleChanged,
+        );
+
   /// Create a new instance
   /// The optional [doubleTapZoomable] boolean defaults to false and allows double tap to zoom.
   const EasyImageView({
     Key? key,
-    required this.imageProvider,
+    required this.imageWidget,
     this.minScale = 1.0,
     this.maxScale = 5.0,
     this.doubleTapZoomable = false,
@@ -52,7 +68,6 @@ class _EasyImageViewState extends State<EasyImageView>
 
   @override
   Widget build(BuildContext context) {
-    final image = Image(image: widget.imageProvider);
     return SizedBox.expand(
         key: const Key('easy_image_sized_box'),
         child: InteractiveViewer(
@@ -64,8 +79,8 @@ class _EasyImageViewState extends State<EasyImageView>
               ? GestureDetector(
                   onDoubleTapDown: _handleDoubleTapDown,
                   onDoubleTap: _handleDoubleTap,
-                  child: image)
-              : image,
+                  child: widget.imageWidget)
+              : widget.imageWidget,
           onInteractionEnd: (scaleEndDetails) {
             double scale = _transformationController.value.getMaxScaleOnAxis();
 

--- a/lib/src/easy_image_view_pager.dart
+++ b/lib/src/easy_image_view_pager.dart
@@ -53,7 +53,8 @@ class _EasyImageViewPagerState extends State<EasyImageViewPager> {
       itemBuilder: (context, index) {
         return EasyImageView(
           key: Key('easy_image_view_$index'),
-          imageWidget: widget.easyImageProvider.imageWidgetBuilder(context, index),
+          imageWidget:
+              widget.easyImageProvider.imageWidgetBuilder(context, index),
           doubleTapZoomable: widget.doubleTapZoomable,
           onScaleChanged: (scale) {
             if (widget.onScaleChanged != null) {

--- a/lib/src/easy_image_view_pager.dart
+++ b/lib/src/easy_image_view_pager.dart
@@ -51,10 +51,9 @@ class _EasyImageViewPagerState extends State<EasyImageViewPager> {
       controller: widget.pageController,
       scrollBehavior: MouseEnabledScrollBehavior(),
       itemBuilder: (context, index) {
-        final image = widget.easyImageProvider.imageBuilder(context, index);
         return EasyImageView(
           key: Key('easy_image_view_$index'),
-          imageProvider: image,
+          imageWidget: widget.easyImageProvider.imageWidgetBuilder(context, index),
           doubleTapZoomable: widget.doubleTapZoomable,
           onScaleChanged: (scale) {
             if (widget.onScaleChanged != null) {

--- a/lib/src/easy_image_viewer_dismissible_dialog.dart
+++ b/lib/src/easy_image_viewer_dismissible_dialog.dart
@@ -77,10 +77,10 @@ class _EasyImageViewerDismissibleDialogState
 
   @override
   Widget build(BuildContext context) {
-    final popScopeAwareDialog = WillPopScope(
-        onWillPop: () async {
+    final popScopeAwareDialog = PopScope(
+        canPop: true,
+        onPopInvoked: (bool didPop) {
           _handleDismissal();
-          return true;
         },
         key: _popScopeKey,
         child: Dialog(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^3.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_image_viewer
 description: An easy image viewer with pinch & zoom, multi image, and built-in full-screen dialog support.
-version: 1.2.1
+version: 1.3.0
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:

--- a/test/easy_image_view_pager_test.dart
+++ b/test/easy_image_view_pager_test.dart
@@ -22,7 +22,7 @@ void main() {
           Colors.teal
         ];
         imageProviders =
-            await Future.wait(colors.map((color) => createColorImage(color)));
+            await Future.wait(colors.map((color) => createColorImageProvider(color)));
       });
 
       final multiImageProvider = MultiImageProvider(imageProviders);

--- a/test/easy_image_view_pager_test.dart
+++ b/test/easy_image_view_pager_test.dart
@@ -53,7 +53,7 @@ void main() {
       PageView pageView = tester.firstWidget(pageViewFinder);
       expect(pageView.controller, pageController);
       EasyImageView easyImageView = tester.firstWidget(easyImageViewFinder);
-      expect(easyImageView.imageProvider, imageProviders.first);
+      expect((easyImageView.imageWidget as Image).image, imageProviders.first);
     });
   });
 }

--- a/test/easy_image_view_test.dart
+++ b/test/easy_image_view_test.dart
@@ -17,8 +17,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView(
-              imageProvider: imageProvider!, minScale: 0.5, maxScale: 6.0));
+          child: EasyImageView.provider(
+              imageProvider!, minScale: 0.5, maxScale: 6.0));
 
       await tester.pumpWidget(testWidget);
 
@@ -56,8 +56,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView(
-              imageProvider: imageProvider!,
+          child: EasyImageView.provider(
+              imageProvider!,
               minScale: 0.5,
               maxScale: 6.0,
               onScaleChanged: (scale) {
@@ -105,8 +105,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView(
-              imageProvider: imageProvider!,
+          child: EasyImageView.provider(
+              imageProvider!,
               minScale: 0.5,
               maxScale: 6.0,
               doubleTapZoomable: true,
@@ -158,8 +158,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView(
-              imageProvider: imageProvider!,
+          child: EasyImageView.provider(
+              imageProvider!,
               minScale: 0.5,
               maxScale: 6.0,
               doubleTapZoomable: true,

--- a/test/easy_image_viewer_test.dart
+++ b/test/easy_image_viewer_test.dart
@@ -14,7 +14,7 @@ void main() {
       bool dismissed = false;
 
       await tester.runAsync(() async {
-        redImageProvider = await createColorImage(Colors.red);
+        redImageProvider = await createColorImageProvider(Colors.red);
       });
 
       final dialogFuture =
@@ -46,7 +46,7 @@ void main() {
       final context = await createTestBuildContext(tester);
 
       await tester.runAsync(() async {
-        imageProvider = await createColorImage(Colors.amber);
+        imageProvider = await createColorImageProvider(Colors.amber);
       });
 
       showImageViewer(context, imageProvider,
@@ -83,7 +83,7 @@ void main() {
           Colors.teal
         ];
         imageProviders =
-            await Future.wait(colors.map((color) => createColorImage(color)));
+            await Future.wait(colors.map((color) => createColorImageProvider(color)));
       });
 
       final multiImageProvider = MultiImageProvider(imageProviders);
@@ -140,7 +140,7 @@ void main() {
           Colors.teal
         ];
         imageProviders =
-            await Future.wait(colors.map((color) => createColorImage(color)));
+            await Future.wait(colors.map((color) => createColorImageProvider(color)));
       });
 
       final multiImageProvider = MultiImageProvider(imageProviders);
@@ -184,7 +184,7 @@ void main() {
           Colors.teal
         ];
         imageProviders =
-            await Future.wait(colors.map((color) => createColorImage(color)));
+            await Future.wait(colors.map((color) => createColorImageProvider(color)));
       });
 
       final multiImageProvider =
@@ -227,7 +227,7 @@ void main() {
       await tester.runAsync(() async {
         const colors = [Colors.amber];
         imageProviders =
-            await Future.wait(colors.map((color) => createColorImage(color)));
+            await Future.wait(colors.map((color) => createColorImageProvider(color)));
       });
 
       final multiImageProvider = MultiImageProvider(imageProviders);

--- a/test/multi_image_provider_test.dart
+++ b/test/multi_image_provider_test.dart
@@ -9,8 +9,8 @@ void main() {
   group('MultiImageProvider', () {
     test('should require a valid initialIndex', () async {
       final imageProviders = [
-        await createColorImage(Colors.red),
-        await createColorImage(Colors.green)
+        await createColorImageProvider(Colors.red),
+        await createColorImageProvider(Colors.green)
       ];
 
       expect(() => MultiImageProvider(imageProviders, initialIndex: -1),
@@ -32,8 +32,8 @@ void main() {
       BuildContext context = await createTestBuildContext(tester);
 
       await tester.runAsync(() async {
-        redImageProvider = await createColorImage(Colors.red);
-        greenImageProvider = await createColorImage(Colors.green);
+        redImageProvider = await createColorImageProvider(Colors.red);
+        greenImageProvider = await createColorImageProvider(Colors.green);
       });
 
       final imageProviders = [redImageProvider!, greenImageProvider!];

--- a/test/single_image_provider_test.dart
+++ b/test/single_image_provider_test.dart
@@ -13,7 +13,7 @@ void main() {
       BuildContext context = await createTestBuildContext(tester);
 
       await tester.runAsync(() async {
-        redImageProvider = await createColorImage(Colors.red);
+        redImageProvider = await createColorImageProvider(Colors.red);
       });
 
       final provider = SingleImageProvider(redImageProvider!);
@@ -24,6 +24,28 @@ void main() {
       expect(provider.imageBuilder(context, 0), redImageProvider);
       expect(() => provider.imageBuilder(context, -1), throwsArgumentError);
       expect(() => provider.imageBuilder(context, 1), throwsArgumentError);
+    });
+
+    testWidgets('should return the correct image widget per index',
+        (WidgetTester tester) async {
+      ImageProvider? redImageProvider;
+      BuildContext context = await createTestBuildContext(tester);
+
+      await tester.runAsync(() async {
+        redImageProvider = await createColorImageProvider(Colors.red);
+      });
+
+      final provider = SingleImageProvider(redImageProvider!);
+
+      expect(provider.imageCount, 1);
+      expect(provider.initialIndex, 0);
+
+      final imageWidget = provider.imageWidgetBuilder(context, 0);
+      expect(imageWidget is Image, true);
+      expect((imageWidget as Image).image, redImageProvider);
+
+      expect(() => provider.imageWidgetBuilder(context, -1), throwsArgumentError);
+      expect(() => provider.imageWidgetBuilder(context, 1), throwsArgumentError);
     });
   });
 }

--- a/test/support/test_helper.dart
+++ b/test/support/test_helper.dart
@@ -2,8 +2,18 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Helper method to create a sample image provider
+Future<ImageProvider> createColorImageProvider(Color color,
+    {double scale = 1.0, int width = 500, int height = 500}) async {
+  
+  final ui.Image image = await createColorImage(color,
+      scale: scale, width: width, height: height);
+  final imageData = await image.toByteData(format: ui.ImageByteFormat.png);
+  return MemoryImage(imageData!.buffer.asUint8List());
+}
+
 /// Helper method to create a sample image
-Future<ImageProvider> createColorImage(Color color,
+Future<ui.Image> createColorImage(Color color,
     {double scale = 1.0, int width = 500, int height = 500}) async {
   final recorder = ui.PictureRecorder();
   final canvas = Canvas(recorder);
@@ -15,9 +25,7 @@ Future<ImageProvider> createColorImage(Color color,
 
   canvas.drawRect(
       Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()), paint);
-  final ui.Image image = await recorder.endRecording().toImage(width, height);
-  final imageData = await image.toByteData(format: ui.ImageByteFormat.png);
-  return MemoryImage(imageData!.buffer.asUint8List());
+  return recorder.endRecording().toImage(width, height);
 }
 
 /// Helper method to create a BuildContext

--- a/test/support/test_image_provider.dart
+++ b/test/support/test_image_provider.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file (https://github.com/flutter/flutter/blob/master/LICENSE).
+
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Taken directly from the Flutter source code
+/// See https://github.com/flutter/flutter/blob/master/packages/flutter/test/widgets/image_test.dart#L2060
+class TestImageProvider extends ImageProvider<Object> {
+  TestImageProvider({ImageStreamCompleter? streamCompleter}) {
+    _streamCompleter = streamCompleter
+      ?? OneFrameImageStreamCompleter(_completer.future);
+  }
+
+  final Completer<ImageInfo> _completer = Completer<ImageInfo>();
+  late ImageStreamCompleter _streamCompleter;
+  late ImageConfiguration lastResolvedConfiguration;
+
+  bool get loadCalled => _loadCallCount > 0;
+  int get loadCallCount => _loadCallCount;
+  int _loadCallCount = 0;
+
+  @override
+  Future<Object> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<TestImageProvider>(this);
+  }
+
+  @override
+  void resolveStreamForKey(ImageConfiguration configuration, ImageStream stream, Object key, ImageErrorListener handleError) {
+    lastResolvedConfiguration = configuration;
+    super.resolveStreamForKey(configuration, stream, key, handleError);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
+    _loadCallCount += 1;
+    return _streamCompleter;
+  }
+
+  void complete(ui.Image image) {
+    _completer.complete(ImageInfo(image: image));
+  }
+
+  void fail(Object exception, StackTrace? stackTrace) {
+    _completer.completeError(exception, stackTrace);
+  }
+
+  @override
+  String toString() => '${describeIdentity(this)}()';
+}

--- a/test/support/test_image_stream_completer.dart
+++ b/test/support/test_image_stream_completer.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file (https://github.com/flutter/flutter/blob/master/LICENSE).
+
+import 'package:flutter/widgets.dart';
+
+/// Taken directly from the Flutter source code
+/// See https://github.com/flutter/flutter/blob/master/packages/flutter/test/widgets/image_test.dart#L2103
+class TestImageStreamCompleter extends ImageStreamCompleter {
+  TestImageStreamCompleter([this._currentImage]);
+
+  ImageInfo? _currentImage;
+  final Set<ImageStreamListener> listeners = <ImageStreamListener>{};
+
+  @override
+  void addListener(ImageStreamListener listener) {
+    listeners.add(listener);
+    if (_currentImage != null) {
+      listener.onImage(_currentImage!.clone(), true);
+    }
+  }
+
+  @override
+  void removeListener(ImageStreamListener listener) {
+    listeners.remove(listener);
+  }
+
+  void setData({
+    ImageInfo? imageInfo,
+    ImageChunkEvent? chunkEvent,
+  }) {
+    if (imageInfo != null) {
+      _currentImage?.dispose();
+      _currentImage = imageInfo;
+    }
+    final List<ImageStreamListener> localListeners = listeners.toList();
+    for (final ImageStreamListener listener in localListeners) {
+      if (imageInfo != null) {
+        listener.onImage(imageInfo.clone(), false);
+      }
+      if (chunkEvent != null && listener.onChunk != null) {
+        listener.onChunk!(chunkEvent);
+      }
+    }
+  }
+
+  void setError({
+    required Object exception,
+    StackTrace? stackTrace,
+  }) {
+    final List<ImageStreamListener> localListeners = listeners.toList();
+    for (final ImageStreamListener listener in localListeners) {
+      listener.onError?.call(exception, stackTrace);
+    }
+  }
+}


### PR DESCRIPTION
This adds support for customizing the Image widget that is being displayed. That includes customizing Image's `frameBuilder` and `loadingBuilder`. Rather than providing those callbacks as parameters, it's more versatile to let the user create their own Image widget using their desired configuration.

This is now supported in `EasyImageProvider` through a new `imageWidgetBuilder` method. The default implementation shows a loading indicator and does a quick fade-in animation once the image is loaded.

However, it's also possible to just customize the widget that is displayed during loading (a `CircularProgressIndicator` by default).

By using your own EasyImageProvider subclass this can be fully customized. 

## Checklist

Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [X] Tests for any changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[ ] Bug fix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[X] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

n/a
