### PR TITLE
Add FutureBuilder example

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -171,10 +171,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -185,6 +187,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/async_demo_page.dart
+++ b/example/lib/async_demo_page.dart
@@ -1,0 +1,62 @@
+import 'package:easy_image_viewer/easy_image_viewer.dart';
+import 'package:flutter/material.dart';
+
+/// Simple example of how to use EasyImageViewer with a FutureBuilder
+class AsyncDemoPage extends StatefulWidget {
+  const AsyncDemoPage({Key? key}) : super(key: key);
+
+  @override
+  _AsyncDemoPageState createState() => _AsyncDemoPageState();
+}
+
+class _AsyncDemoPageState extends State<AsyncDemoPage> {
+
+  final _pageController = PageController();
+
+  /// Simulates a network fetch of image URLs
+  Future<List<String>> _fetchURLs() async {
+    // Wait for three seconds to simulate a network fetch
+    await Future.delayed(const Duration(seconds: 3));
+
+    return [
+      "https://picsum.photos/id/1001/4912/3264",
+      "https://picsum.photos/id/1003/1181/1772",
+      "https://picsum.photos/id/1004/4912/3264",
+      "https://picsum.photos/id/1005/4912/3264"
+    ];
+  }
+
+  /// Creates an EasyImageProvider from a list of URLs
+  Future<EasyImageProvider> _createEasyImageProvider() async {
+    final urls = await _fetchURLs();
+    return MultiImageProvider(urls.map((url) => NetworkImage(url)).toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Async Demo')),
+      body: FutureBuilder<EasyImageProvider>(
+        future: _createEasyImageProvider(),
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            EasyImageProvider easyImageProvider = snapshot.data!;
+            return Center(child: 
+              SizedBox(
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.height / 2.0,
+                child: EasyImageViewPager(
+                    easyImageProvider: easyImageProvider,
+                    pageController: _pageController),
+              )
+            );
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else {
+            return const Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:easy_image_viewer/easy_image_viewer.dart';
+import 'package:easy_image_viewer_example/async_demo_page.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
@@ -91,6 +92,14 @@ class _MyHomePageState extends State<MyHomePage> {
                   // print("Dismissed while on page $page");
                 });
               }),
+          ElevatedButton(
+              child: const Text("Async Demo (FutureBuilder)"),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const AsyncDemoPage()),
+                );
+              }),
           SizedBox(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height / 2.0,
@@ -121,7 +130,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         curve: _kCurve);
                   }),
             ],
-          )
+          ),
         ],
       )),
     );


### PR DESCRIPTION
Added a simple example on how to use EasyImageViewer when you obtain image URLs asynchronously.

This is related to issue #38.

