### PR TITLE
Revert breaking constructor change introduced in 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EasyImageViewer Changelog
 
+## 1.3.1
+
+- Revert breaking constructor change introduced in 1.3.0. This changes the default `EasyImageView` constructor back to accepting an `ImageProvider` instead of a `Widget`. Constructing an `EasyImageView` with a widget can be done by using a new named constructor: `EasyImageView.imageWidget`.
+
 ## 1.3.0
 
 - Update Flutter to `3.16.3`

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -114,9 +114,15 @@ class _MyHomePageState extends State<MyHomePage> {
                 );
                 showImageViewerPager(context, customImageProvider);
               }),
+          SizedBox( // Tiny image just to test the EasyImageView constructor
+            width: MediaQuery.of(context).size.width,
+            height: 56,
+            child: EasyImageView(
+                imageProvider: Image.network("https://picsum.photos/id/1001/4912/3264").image)
+          ),
           SizedBox(
             width: MediaQuery.of(context).size.width,
-            height: MediaQuery.of(context).size.height / 2.0,
+            height: MediaQuery.of(context).size.height / 2.4,
             child: EasyImageViewPager(
                 easyImageProvider: _easyEmbeddedImageProvider,
                 pageController: _pageController),

--- a/lib/src/easy_image_view.dart
+++ b/lib/src/easy_image_view.dart
@@ -19,15 +19,16 @@ class EasyImageView extends StatefulWidget {
   final void Function(double)? onScaleChanged;
 
   /// Create a new instance that accepts an [ImageProvider]
-  EasyImageView.provider(ImageProvider imageProvider,
-      {Key? key,
-      double minScale = 1.0,
-      double maxScale = 5.0,
-      bool doubleTapZoomable = false,
-      void Function(double)? onScaleChanged})
-      : this(
+  EasyImageView({
+    Key? key,
+    required ImageProvider imageProvider,
+    double minScale = 1.0,
+    double maxScale = 5.0,
+    bool doubleTapZoomable = false,
+    void Function(double)? onScaleChanged,
+  }) : this.imageWidget(
+          Image(image: imageProvider),
           key: key,
-          imageWidget: Image(image: imageProvider),
           minScale: minScale,
           maxScale: maxScale,
           doubleTapZoomable: doubleTapZoomable,
@@ -36,9 +37,9 @@ class EasyImageView extends StatefulWidget {
 
   /// Create a new instance
   /// The optional [doubleTapZoomable] boolean defaults to false and allows double tap to zoom.
-  const EasyImageView({
+  const EasyImageView.imageWidget(
+    this.imageWidget, {
     Key? key,
-    required this.imageWidget,
     this.minScale = 1.0,
     this.maxScale = 5.0,
     this.doubleTapZoomable = false,

--- a/lib/src/easy_image_view_pager.dart
+++ b/lib/src/easy_image_view_pager.dart
@@ -51,10 +51,9 @@ class _EasyImageViewPagerState extends State<EasyImageViewPager> {
       controller: widget.pageController,
       scrollBehavior: MouseEnabledScrollBehavior(),
       itemBuilder: (context, index) {
-        return EasyImageView(
+        return EasyImageView.imageWidget(
+          widget.easyImageProvider.imageWidgetBuilder(context, index),
           key: Key('easy_image_view_$index'),
-          imageWidget:
-              widget.easyImageProvider.imageWidgetBuilder(context, index),
           doubleTapZoomable: widget.doubleTapZoomable,
           onScaleChanged: (scale) {
             if (widget.onScaleChanged != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_image_viewer
 description: An easy image viewer with pinch & zoom, multi image, and built-in full-screen dialog support.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:

--- a/test/easy_image_view_test.dart
+++ b/test/easy_image_view_test.dart
@@ -22,8 +22,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView.provider(
-              imageProvider!, minScale: 0.5, maxScale: 6.0));
+          child: EasyImageView(
+              imageProvider: imageProvider!, minScale: 0.5, maxScale: 6.0));
 
       await tester.pumpWidget(testWidget);
 
@@ -61,8 +61,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView.provider(
-              imageProvider!,
+          child: EasyImageView(
+              imageProvider: imageProvider!,
               minScale: 0.5,
               maxScale: 6.0,
               onScaleChanged: (scale) {
@@ -110,8 +110,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView.provider(
-              imageProvider!,
+          child: EasyImageView(
+              imageProvider: imageProvider!,
               minScale: 0.5,
               maxScale: 6.0,
               doubleTapZoomable: true,
@@ -163,8 +163,8 @@ void main() {
 
       Widget testWidget = MediaQuery(
           data: const MediaQueryData(size: Size(600, 800)),
-          child: EasyImageView.provider(
-              imageProvider!,
+          child: EasyImageView(
+              imageProvider: imageProvider!,
               minScale: 0.5,
               maxScale: 6.0,
               doubleTapZoomable: true,
@@ -214,7 +214,7 @@ void main() {
           data: const MediaQueryData(size: Size(600, 800)),
           child: Directionality(
               textDirection: TextDirection.ltr,
-              child: EasyImageView(imageWidget: provider.imageWidgetBuilder(context, 0))));
+              child: EasyImageView.imageWidget(provider.imageWidgetBuilder(context, 0))));
 
       await tester.pumpWidget(testWidget);
 


### PR DESCRIPTION
Revert breaking constructor change introduced in 1.3.0. This changes the default `EasyImageView` constructor back to accepting an `ImageProvider` instead of a `Widget`. Constructing an `EasyImageView` with a widget can be done by using a new named constructor: `EasyImageView.imageWidget`.

Thank you to @wferem1 for reporting this.

## Description

<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->

Todo

## Checklist

Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [X] Tests for any changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[ ] Bug fix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[X] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

See description above.
