### PR TITLE
Fix: Revert breaking change from WillPopScope to PopScope to avoid higher Flutter version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # EasyImageViewer Changelog
 
+## 1.3.2
+- Revert change from `WillPopScope` to `PopScope` introduced in 1.3.0. It would require bumping up the minimum Flutter version. We will re-introduce that change when in the next major version.
+
 ## 1.3.1
 
 - Revert breaking constructor change introduced in 1.3.0. This changes the default `EasyImageView` constructor back to accepting an `ImageProvider` instead of a `Widget`. Constructing an `EasyImageView` with a widget can be done by using a new named constructor: `EasyImageView.imageWidget`.

--- a/lib/src/easy_image_viewer_dismissible_dialog.dart
+++ b/lib/src/easy_image_viewer_dismissible_dialog.dart
@@ -77,10 +77,12 @@ class _EasyImageViewerDismissibleDialogState
 
   @override
   Widget build(BuildContext context) {
-    final popScopeAwareDialog = PopScope(
-        canPop: true,
-        onPopInvoked: (bool didPop) {
+    // Remove this once we release v2.0.0 and can bump the minimum Flutter version to 3.13.0
+    // ignore: deprecated_member_use
+    final popScopeAwareDialog = WillPopScope(
+        onWillPop: () async {
           _handleDismissal();
+          return true;
         },
         key: _popScopeKey,
         child: Dialog(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_image_viewer
 description: An easy image viewer with pinch & zoom, multi image, and built-in full-screen dialog support.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:


### PR DESCRIPTION
In 1.3.0 a deprecation warning was addressed by changing WillPopScope to PopScope in one place. However, PopScope requires Flutter 3.13.0 and I had omitted to bump the minimum Flutter version, which would be a breaking change. To avoid that, roll back the change and ignore the deprecation warning until we release a major version.

