### PR TITLE
Adjust GitHub Actions to run tests on multiple versions of Flutter

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['any', '3.7.0', '2.5.0']  # Specify versions here
+        flutter-version: ['any', '3.0.0', '3.7.0', '3.10.0']  # Specify versions here
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,8 +12,11 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flutter-version: ['any', '3.7.0', '2.5.0']  # Specify versions here
 
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +26,9 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
+          flutter-version: ${{ matrix.flutter-version }}
+      - name: Print version
+        run: flutter --version
       - name: Install dependencies
         run: flutter pub get
       - name: Analyze project source

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           flutter-version: ${{ matrix.flutter-version }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['any', '3.0.0', '3.7.0', '3.10.0']  # Specify versions here
+        flutter-version: ['any', '3.7.0', '3.10.0', '3.16.3']  # Specify versions here
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # EasyImageViewer Changelog
 
+## 1.4.1
+- Clearly declare Flutter 3.7.0 and Dart 2.19.0 as the minimum supported versions. Fixes a "const Column" error when used with Flutter versions lower than 3.10.0 (see [GH-52](https://github.com/thesmythgroup/easy_image_viewer/issues/52)).
+
 ## 1.4.0
 - Add a default error widget that is shown when an image fails to load. The default error widget shows a red `Icons.broken_image` and '🖼️💥🚫' (image, boom, no entry) as a message underneath. You can customize the error widget by subclassing `EasyImageProvider` and overriding `errorWidgetBuilder`. See the README for an example.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ An easy way to display images in a full-screen dialog, including pinch & zoom.
 * Callbacks for `onPageChanged` and `onViewerDismissed`
 * Fully customizable loading/progress indicator
 
+## Requirements
+
+EasyImageViewer requires Flutter 3.7.0 and Dart 2.19.0 or higher.
+
 ## Usage
 
 Show a single image:

--- a/lib/src/easy_image_provider.dart
+++ b/lib/src/easy_image_provider.dart
@@ -81,10 +81,14 @@ abstract class EasyImageProvider {
   /// The [stackTrace] parameter is the stack trace associated with the error.
   Widget errorWidgetBuilder(
       BuildContext context, int index, Object error, StackTrace? stackTrace) {
-    return const Center(
+    // Remove once the minimum Flutter version is 3.10+
+    // ignore: prefer_const_constructors
+    return Center(
+      // Remove once the minimum Flutter version is 3.10+
+      // ignore: prefer_const_constructors
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
+        children: const <Widget>[
           Icon(
             Icons.broken_image,
             color: Colors.red,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.4.0
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"  # This implies at least Dart 2.17, which comes with Flutter 3.0
-  flutter: ">=3.0.0"
+  sdk: ">=2.19.0 <4.0.0"  # This implies at least Dart 2.19, which comes with Flutter 3.7.0
+  flutter: ">=3.7.0"
 
 topics:
   - image
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: 2.0.1
+  flutter_lints: 2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_image_viewer
 description: An easy image viewer with pinch & zoom, multi image, and built-in full-screen dialog support.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.4.0
 homepage: https://github.com/thesmythgroup/easy_image_viewer
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=2.17.0 <4.0.0"  # This implies at least Dart 2.17, which comes with Flutter 3.0
+  flutter: ">=3.0.0"
 
 topics:
   - image

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: 2.0.1

--- a/test/support/test_image_provider.dart
+++ b/test/support/test_image_provider.dart
@@ -36,10 +36,19 @@ class TestImageProvider extends ImageProvider<Object> {
   }
 
   @override
-  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
+  // Remove once the minimum Flutter version is 3.16+
+  // ignore: deprecated_member_use
+  ImageStreamCompleter loadBuffer(Object key, DecoderBufferCallback decode) {
     _loadCallCount += 1;
     return _streamCompleter;
   }
+
+  // Use once the minimum Flutter version is 3.16+
+  // @override
+  // ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
+  //   _loadCallCount += 1;
+  //   return _streamCompleter;
+  // }
 
   void complete(ui.Image image) {
     _completer.complete(ImageInfo(image: image));


### PR DESCRIPTION
The reason is to be better equipped to catch issues that only happen on older or newer versions of Flutter.