### PR TITLE
Double-tap zoom scale

### DIFF
--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -27,6 +27,9 @@ const _defaultCloseButtonTooltip = 'Close';
 /// The optional [useSafeArea] boolean defaults to false and is passed to [showDialog].
 /// The optional [swipeDismissible] boolean defaults to false and allows swipe-down-to-dismiss.
 /// The optional [doubleTapZoomable] boolean defaults to false and allows double tap to zoom.
+/// The optional [doubleTapZoomScale] defines how much to zoom on double tap.
+/// The optional [minScale] defines how much user can manually zoom out.
+/// The optional [maxScale] defines how much user can manually zoom in.
 /// The [backgroundColor] defaults to black, but can be set to any other color.
 /// The optional [barrierColor] (in connection with [useSafeArea]) defaults to the [backgroundColor], but can be set to any other color.
 /// The [closeButtonTooltip] text is displayed when the user long-presses on the
@@ -39,6 +42,9 @@ Future<Dialog?> showImageViewer(
     bool useSafeArea = false,
     bool swipeDismissible = false,
     bool doubleTapZoomable = false,
+    double doubleTapZoomScale = 2,
+    double minScale = 1,
+    double maxScale = 5,
     Color backgroundColor = _defaultBackgroundColor,
     Color? barrierColor,
     String closeButtonTooltip = _defaultCloseButtonTooltip,
@@ -79,6 +85,9 @@ Future<Dialog?> showImageViewerPager(
     bool useSafeArea = false,
     bool swipeDismissible = false,
     bool doubleTapZoomable = false,
+    double doubleTapZoomScale = 2,
+    double minScale = 1,
+    double maxScale = 5,
     bool infinitelyScrollable = false,
     Color backgroundColor = _defaultBackgroundColor,
     Color? barrierColor,
@@ -100,6 +109,9 @@ Future<Dialog?> showImageViewerPager(
             onViewerDismissed: onViewerDismissed,
             swipeDismissible: swipeDismissible,
             doubleTapZoomable: doubleTapZoomable,
+            doubleTapZoomScale: doubleTapZoomScale,
+            minScale: minScale,
+            maxScale: maxScale,
             infinitelyScrollable: infinitelyScrollable,
             backgroundColor: backgroundColor,
             closeButtonColor: closeButtonColor,

--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -56,6 +56,7 @@ Future<Dialog?> showImageViewer(
       useSafeArea: useSafeArea,
       swipeDismissible: swipeDismissible,
       doubleTapZoomable: doubleTapZoomable,
+      doubleTapZoomScale: doubleTapZoomScale,
       backgroundColor: backgroundColor,
       barrierColor: barrierColor,
       closeButtonTooltip: closeButtonTooltip,

--- a/lib/src/easy_image_view.dart
+++ b/lib/src/easy_image_view.dart
@@ -14,6 +14,9 @@ class EasyImageView extends StatefulWidget {
   /// Whether to allow double tap to zoom in and out
   final bool doubleTapZoomable;
 
+  /// How much to zoom during double tap zoom in
+  final double doubleTapZoomScale;
+
   /// Callback for when the scale has changed, only invoked at the end of
   /// an interaction.
   final void Function(double)? onScaleChanged;
@@ -25,6 +28,7 @@ class EasyImageView extends StatefulWidget {
     double minScale = 1.0,
     double maxScale = 5.0,
     bool doubleTapZoomable = false,
+    double doubleTapZoomScale = 2.0,
     void Function(double)? onScaleChanged,
   }) : this.imageWidget(
           Image(image: imageProvider),
@@ -32,6 +36,7 @@ class EasyImageView extends StatefulWidget {
           minScale: minScale,
           maxScale: maxScale,
           doubleTapZoomable: doubleTapZoomable,
+          doubleTapZoomScale: doubleTapZoomScale,
           onScaleChanged: onScaleChanged,
         );
 
@@ -43,6 +48,7 @@ class EasyImageView extends StatefulWidget {
     this.minScale = 1.0,
     this.maxScale = 5.0,
     this.doubleTapZoomable = false,
+    this.doubleTapZoomScale = 2.0,
     this.onScaleChanged,
   }) : super(key: key);
 
@@ -102,18 +108,18 @@ class _EasyImageViewState extends State<EasyImageView>
 
     double scale = _transformationController.value.getMaxScaleOnAxis();
 
-    if (scale < 2.0) {
-      // If we are not at a 2x scale yet, zoom in all the way to 2x.
+    if (scale < widget.doubleTapZoomScale) {
+      // If we are not at a doubleTapZoomScale yet, zoom in all the way to it.
       final position = _doubleTapDetails.localPosition;
       final begin = _transformationController.value;
       final end = Matrix4.identity()
         ..translate(-position.dx, -position.dy)
-        ..scale(2.0);
+        ..scale(widget.doubleTapZoomScale);
 
       _updateDoubleTapAnimation(begin, end);
       _animationController.forward(from: 0.0);
     } else {
-      // If we are zoomed in at 2x or more, zoom all the way out
+      // If we are zoomed in at doubleTapZoomScale or more, zoom all the way out
       final begin = Matrix4.identity();
       final end = _transformationController.value;
 

--- a/lib/src/easy_image_view.dart
+++ b/lib/src/easy_image_view.dart
@@ -113,8 +113,12 @@ class _EasyImageViewState extends State<EasyImageView>
       final position = _doubleTapDetails.localPosition;
       final begin = _transformationController.value;
       final end = Matrix4.identity()
-        ..translate(-position.dx, -position.dy)
-        ..scale(widget.doubleTapZoomScale);
+        ..scale(widget.doubleTapZoomScale)
+        ..translate(
+          position.dx/widget.doubleTapZoomScale - position.dx,
+          position.dy/widget.doubleTapZoomScale - position.dy,
+        )
+      ;
 
       _updateDoubleTapAnimation(begin, end);
       _animationController.forward(from: 0.0);

--- a/lib/src/easy_image_view_pager.dart
+++ b/lib/src/easy_image_view_pager.dart
@@ -17,6 +17,9 @@ class EasyImageViewPager extends StatefulWidget {
   final EasyImageProvider easyImageProvider;
   final PageController pageController;
   final bool doubleTapZoomable;
+  final double doubleTapZoomScale;
+  final double minScale;
+  final double maxScale;
   final bool infinitelyScrollable;
 
   /// Callback for when the scale has changed, only invoked at the end of
@@ -26,11 +29,17 @@ class EasyImageViewPager extends StatefulWidget {
   /// Create new instance, using the [easyImageProvider] to populate the [PageView],
   /// and the [pageController] to control the initial image index to display.
   /// The optional [doubleTapZoomable] boolean defaults to false and allows double tap to zoom.
+  /// The optional [doubleTapZoomScale] defines how much to zoom on double tap.
+  /// The optional [minScale] defines how much user can manually zoom out.
+  /// The optional [maxScale] defines how much user can manually zoom in.
   const EasyImageViewPager({
     Key? key,
     required this.easyImageProvider,
     required this.pageController,
     this.doubleTapZoomable = false,
+    this.doubleTapZoomScale = 2,
+    this.minScale = 1,
+    this.maxScale = 5,
     this.onScaleChanged,
     this.infinitelyScrollable = false,
   }) : super(key: key);
@@ -60,6 +69,9 @@ class _EasyImageViewPagerState extends State<EasyImageViewPager> {
           widget.easyImageProvider.imageWidgetBuilder(context, pageIndex),
           key: Key('easy_image_view_$pageIndex'),
           doubleTapZoomable: widget.doubleTapZoomable,
+          doubleTapZoomScale: widget.doubleTapZoomScale,
+          minScale: widget.minScale,
+          maxScale: widget.maxScale,
           onScaleChanged: (scale) {
             if (widget.onScaleChanged != null) {
               widget.onScaleChanged!(scale);

--- a/lib/src/easy_image_viewer_dismissible_dialog.dart
+++ b/lib/src/easy_image_viewer_dismissible_dialog.dart
@@ -15,6 +15,9 @@ class EasyImageViewerDismissibleDialog extends StatefulWidget {
   final void Function(int)? onViewerDismissed;
   final bool swipeDismissible;
   final bool doubleTapZoomable;
+  final double doubleTapZoomScale;
+  final double minScale;
+  final double maxScale;
   final Color backgroundColor;
   final String closeButtonTooltip;
   final Color closeButtonColor;
@@ -28,6 +31,9 @@ class EasyImageViewerDismissibleDialog extends StatefulWidget {
       this.onViewerDismissed,
       this.swipeDismissible = false,
       this.doubleTapZoomable = false,
+      this.doubleTapZoomScale = 2,
+      this.minScale = 1,
+      this.maxScale = 5,
       this.infinitelyScrollable = false,
       required this.backgroundColor,
       required this.closeButtonTooltip,

--- a/lib/src/easy_image_viewer_dismissible_dialog.dart
+++ b/lib/src/easy_image_viewer_dismissible_dialog.dart
@@ -106,6 +106,9 @@ class _EasyImageViewerDismissibleDialogState
                       easyImageProvider: widget.imageProvider,
                       pageController: _pageController,
                       doubleTapZoomable: widget.doubleTapZoomable,
+                      doubleTapZoomScale: widget.doubleTapZoomScale,
+                      minScale: widget.minScale,
+                      maxScale: widget.maxScale,
                       infinitelyScrollable: widget.infinitelyScrollable,
                       onScaleChanged: (scale) {
                         setState(() {


### PR DESCRIPTION
## Description

Introduce a new parameter to allow library users to modify how much an image will be zoomed in on double tap.

We have also exposed `minScale` and `maxScale` on the main entry-point `showImageViewer`.

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[ ] Bug fix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[x] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

Tests already cover this use case
