### PR TITLE
Additional params passthrough to showDialog

### DIFF
--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -10,11 +10,10 @@ import 'src/easy_image_viewer_dismissible_dialog.dart';
 import 'src/single_image_provider.dart';
 
 export 'src/easy_image_provider.dart' show EasyImageProvider;
-export 'src/single_image_provider.dart' show SingleImageProvider;
-export 'src/multi_image_provider.dart' show MultiImageProvider;
-
 export 'src/easy_image_view.dart' show EasyImageView;
 export 'src/easy_image_view_pager.dart' show EasyImageViewPager;
+export 'src/multi_image_provider.dart' show MultiImageProvider;
+export 'src/single_image_provider.dart' show SingleImageProvider;
 
 // Defined here so we don't repeat ourselves
 const _defaultBackgroundColor = Colors.black;
@@ -32,11 +31,12 @@ const _defaultCloseButtonTooltip = 'Close';
 /// The [closeButtonTooltip] text is displayed when the user long-presses on the
 /// close button and is used for accessibility.
 /// The [closeButtonColor] defaults to white, but can be set to any other color.
-Future<Dialog?> showImageViewer(
-    BuildContext context, ImageProvider imageProvider,
+Future<Dialog?> showImageViewer(BuildContext context, ImageProvider imageProvider,
     {bool immersive = true,
     void Function()? onViewerDismissed,
     bool useSafeArea = false,
+    bool useRootNavigator = true,
+    RouteSettings? routeSettings,
     bool swipeDismissible = false,
     bool doubleTapZoomable = false,
     Color backgroundColor = _defaultBackgroundColor,
@@ -45,9 +45,10 @@ Future<Dialog?> showImageViewer(
     Color closeButtonColor = _defaultCloseButtonColor}) {
   return showImageViewerPager(context, SingleImageProvider(imageProvider),
       immersive: immersive,
-      onViewerDismissed:
-          onViewerDismissed != null ? (_) => onViewerDismissed() : null,
+      onViewerDismissed: onViewerDismissed != null ? (_) => onViewerDismissed() : null,
       useSafeArea: useSafeArea,
+      useRootNavigator: useRootNavigator,
+      routeSettings: routeSettings,
       swipeDismissible: swipeDismissible,
       doubleTapZoomable: doubleTapZoomable,
       backgroundColor: backgroundColor,
@@ -71,12 +72,13 @@ Future<Dialog?> showImageViewer(
 /// The [closeButtonTooltip] text is displayed when the user long-presses on the
 /// close button and is used for accessibility.
 /// The [closeButtonColor] defaults to white, but can be set to any other color.
-Future<Dialog?> showImageViewerPager(
-    BuildContext context, EasyImageProvider imageProvider,
+Future<Dialog?> showImageViewerPager(BuildContext context, EasyImageProvider imageProvider,
     {bool immersive = true,
     void Function(int)? onPageChanged,
     void Function(int)? onViewerDismissed,
     bool useSafeArea = false,
+    bool useRootNavigator = true,
+    RouteSettings? routeSettings,
     bool swipeDismissible = false,
     bool doubleTapZoomable = false,
     bool infinitelyScrollable = false,
@@ -92,6 +94,8 @@ Future<Dialog?> showImageViewerPager(
   return showDialog<Dialog>(
       context: context,
       useSafeArea: useSafeArea,
+      useRootNavigator: useRootNavigator,
+      routeSettings: routeSettings,
       barrierColor: barrierColor ?? backgroundColor,
       builder: (context) {
         return EasyImageViewerDismissibleDialog(imageProvider,

--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -10,8 +10,8 @@ import 'src/easy_image_viewer_dismissible_dialog.dart';
 import 'src/single_image_provider.dart';
 
 export 'src/easy_image_provider.dart' show EasyImageProvider;
-export 'src/multi_image_provider.dart' show MultiImageProvider;
 export 'src/single_image_provider.dart' show SingleImageProvider;
+export 'src/multi_image_provider.dart' show MultiImageProvider;
 
 export 'src/easy_image_view.dart' show EasyImageView;
 export 'src/easy_image_view_pager.dart' show EasyImageViewPager;

--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -10,10 +10,11 @@ import 'src/easy_image_viewer_dismissible_dialog.dart';
 import 'src/single_image_provider.dart';
 
 export 'src/easy_image_provider.dart' show EasyImageProvider;
-export 'src/easy_image_view.dart' show EasyImageView;
-export 'src/easy_image_view_pager.dart' show EasyImageViewPager;
 export 'src/multi_image_provider.dart' show MultiImageProvider;
 export 'src/single_image_provider.dart' show SingleImageProvider;
+
+export 'src/easy_image_view.dart' show EasyImageView;
+export 'src/easy_image_view_pager.dart' show EasyImageViewPager;
 
 // Defined here so we don't repeat ourselves
 const _defaultBackgroundColor = Colors.black;
@@ -31,7 +32,8 @@ const _defaultCloseButtonTooltip = 'Close';
 /// The [closeButtonTooltip] text is displayed when the user long-presses on the
 /// close button and is used for accessibility.
 /// The [closeButtonColor] defaults to white, but can be set to any other color.
-Future<Dialog?> showImageViewer(BuildContext context, ImageProvider imageProvider,
+Future<Dialog?> showImageViewer(
+    BuildContext context, ImageProvider imageProvider,
     {bool immersive = true,
     void Function()? onViewerDismissed,
     bool useSafeArea = false,
@@ -45,7 +47,8 @@ Future<Dialog?> showImageViewer(BuildContext context, ImageProvider imageProvide
     Color closeButtonColor = _defaultCloseButtonColor}) {
   return showImageViewerPager(context, SingleImageProvider(imageProvider),
       immersive: immersive,
-      onViewerDismissed: onViewerDismissed != null ? (_) => onViewerDismissed() : null,
+      onViewerDismissed:
+          onViewerDismissed != null ? (_) => onViewerDismissed() : null,
       useSafeArea: useSafeArea,
       useRootNavigator: useRootNavigator,
       routeSettings: routeSettings,
@@ -72,7 +75,8 @@ Future<Dialog?> showImageViewer(BuildContext context, ImageProvider imageProvide
 /// The [closeButtonTooltip] text is displayed when the user long-presses on the
 /// close button and is used for accessibility.
 /// The [closeButtonColor] defaults to white, but can be set to any other color.
-Future<Dialog?> showImageViewerPager(BuildContext context, EasyImageProvider imageProvider,
+Future<Dialog?> showImageViewerPager(
+    BuildContext context, EasyImageProvider imageProvider,
     {bool immersive = true,
     void Function(int)? onPageChanged,
     void Function(int)? onViewerDismissed,

--- a/lib/easy_image_viewer.dart
+++ b/lib/easy_image_viewer.dart
@@ -25,6 +25,8 @@ const _defaultCloseButtonTooltip = 'Close';
 /// Setting [immersive] to false will prevent the top and bottom bars from being hidden.
 /// The optional [onViewerDismissed] callback function is called when the dialog is closed.
 /// The optional [useSafeArea] boolean defaults to false and is passed to [showDialog].
+/// The optional [useRootNavigator] boolean defaults to true and is passed to [showDialog].
+/// The optional [routeSettings] defaults to null and is passed to [showDialog].
 /// The optional [swipeDismissible] boolean defaults to false and allows swipe-down-to-dismiss.
 /// The optional [doubleTapZoomable] boolean defaults to false and allows double tap to zoom.
 /// The [backgroundColor] defaults to black, but can be set to any other color.
@@ -67,6 +69,8 @@ Future<Dialog?> showImageViewer(
 /// The optional [onViewerDismissed] callback function is called with the index of
 /// the image that is displayed when the dialog is closed.
 /// The optional [useSafeArea] boolean defaults to false and is passed to [showDialog].
+/// The optional [useRootNavigator] boolean defaults to true and is passed to [showDialog].
+/// The optional [routeSettings] defaults to null and is passed to [showDialog].
 /// The optional [swipeDismissible] boolean defaults to false and allows swipe-down-to-dismiss.
 /// The optional [doubleTapZoomable] boolean defaults to false and allows double tap to zoom.
 /// The optional [infinitelyScrollable] boolean defaults to false and allows infinite scrolling.


### PR DESCRIPTION
Additional params passthrough to showDialog:
bool useRootNavigator = true,
RouteSettings? routeSettings,

## Description

Possibility to show this dialog form another one dialog using useRootNavigator = false 
Also with this changes i can control RouteSettings. E.g. URL Path on WEB 

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[ ] Bug fix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[x] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

n/a
